### PR TITLE
Fixed invalid warning on global namespace for compiler-generated top-level Program class

### DIFF
--- a/coverage.bat
+++ b/coverage.bat
@@ -4,7 +4,7 @@ md coverage
 
 set configuration=Debug
 set opencover="%USERPROFILE%\.nuget\packages\OpenCover\4.7.1221\tools\OpenCover.Console.exe"
-set reportgenerator="%USERPROFILE%\.nuget\packages\ReportGenerator\4.8.12\tools\net47\ReportGenerator.exe"
+set reportgenerator="%USERPROFILE%\.nuget\packages\ReportGenerator\5.0.0\tools\net47\ReportGenerator.exe"
 set testrunner="%USERPROFILE%\.nuget\packages\xunit.runner.console\2.4.1\tools\net472\xunit.console.x86.exe"
 set target=".\src\CSharpGuidelinesAnalyzer\CSharpGuidelinesAnalyzer.Test\bin\%configuration%\net48\CSharpGuidelinesAnalyzer.Test.dll -noshadow"
 set filter="+[CSharpGuidelinesAnalyzer*]*  -[CSharpGuidelinesAnalyzer.Test*]*"

--- a/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.Test/CSharpGuidelinesAnalyzer.Test.csproj
+++ b/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.Test/CSharpGuidelinesAnalyzer.Test.csproj
@@ -21,12 +21,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="OpenCover" Version="4.7.1221" />
-    <PackageReference Include="ReportGenerator" Version="4.8.12" />
+    <PackageReference Include="ReportGenerator" Version="5.0.0" />
     <PackageReference Include="ResharperCodeContractNullability" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.csproj
+++ b/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.csproj
@@ -46,8 +46,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="all" />
-    <PackageReference Include="JetBrains.ExternalAnnotations" Version="10.2.100" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.ExternalAnnotations" Version="10.2.103" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" PrivateAssets="all" />
     <PackageReference Include="ResharperCodeContractNullability" Version="2.0.2" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #126.