### PR TITLE
AV1551: Ignore CancellationToken parameter in ordering, which always comes last by convention

### DIFF
--- a/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer/Rules/Maintainability/OverloadShouldCallOtherOverloadAnalyzer.cs
+++ b/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer/Rules/Maintainability/OverloadShouldCallOtherOverloadAnalyzer.cs
@@ -216,7 +216,12 @@ public sealed class OverloadShouldCallOtherOverloadAnalyzer : DiagnosticAnalyzer
 
     private static bool IsRegularParameter([NotNull] IParameterSymbol parameter)
     {
-        return parameter is { HasExplicitDefaultValue: false, IsParams: false };
+        return parameter is { HasExplicitDefaultValue: false, IsParams: false } && !IsCancellationToken(parameter.Type);
+    }
+
+    private static bool IsCancellationToken([NotNull] ITypeSymbol type)
+    {
+        return type.ToDisplayString() == "System.Threading.CancellationToken";
     }
 
     private static bool AreDefaultParametersDeclaredInSameOrder([NotNull] IMethodSymbol method,


### PR DESCRIPTION
Fixes #153.