### PR TITLE
use correct framework

### DIFF
--- a/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.Test/CSharpGuidelinesAnalyzer.Test.csproj
+++ b/src/CSharpGuidelinesAnalyzer/CSharpGuidelinesAnalyzer.Test/CSharpGuidelinesAnalyzer.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DefineConstants>TRACE;RELEASE;JETBRAINS_ANNOTATIONS</DefineConstants>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks